### PR TITLE
getType() of EsriPolylineMList properly overridden

### DIFF
--- a/src/openmap/com/bbn/openmap/dataAccess/shape/EsriPolylineMList.java
+++ b/src/openmap/com/bbn/openmap/dataAccess/shape/EsriPolylineMList.java
@@ -40,7 +40,6 @@ public class EsriPolylineMList extends EsriPolylineList {
      */
     public EsriPolylineMList() {
         super();
-        setType(SHAPE_TYPE_POLYLINEM);
     }
 
     /**
@@ -54,6 +53,13 @@ public class EsriPolylineMList extends EsriPolylineList {
 
     public EsriPolyline convert(OMPoly ompoly) {
         return EsriPolylineM.convert(ompoly);
+    }
+
+    /**
+     * Get the list type in ESRI type number form - 23.
+     */
+    public int getType() {
+        return SHAPE_TYPE_POLYLINEM;
     }
 
     public EsriGraphic shallowCopy() {


### PR DESCRIPTION
This doesn't work:
```java
    setType(SHAPE_TYPE_POLYLINEM);
```
Due to a:
```java
    public class EsriPolylineList {
    public int getType() {
        return SHAPE_TYPE_POLYLINE;
    }
    }
```