### PR TITLE
Added tneenot patch about ISO format problem (ASRP, CADRG, USRP) for testing

### DIFF
--- a/src/openmap/com/bbn/openmap/dataAccess/iso8211/DDFConstants.java
+++ b/src/openmap/com/bbn/openmap/dataAccess/iso8211/DDFConstants.java
@@ -29,5 +29,6 @@ public interface DDFConstants {
     public final static char DDF_LEADER_SIZE = 24;
     public final static char DDF_FIELD_TERMINATOR = 30;
     public final static char DDF_UNIT_TERMINATOR = 31;
+    public final static char DDF_FOOTER_SIZE = 53;
 
 }

--- a/src/openmap/com/bbn/openmap/dataAccess/iso8211/DDFModule.java
+++ b/src/openmap/com/bbn/openmap/dataAccess/iso8211/DDFModule.java
@@ -263,6 +263,14 @@ public class DDFModule implements DDFConstants {
         return fpDDF;
     }
 
+    public long getFileLength() throws IOException {
+        return fpDDF.length();
+    }
+
+    public int getRecordLength() throws IOException {
+        return _recLength;
+    }
+
     /**
      * Write out module info to debugging file.
      * 

--- a/src/openmap/com/bbn/openmap/dataAccess/iso8211/DDFRecord.java
+++ b/src/openmap/com/bbn/openmap/dataAccess/iso8211/DDFRecord.java
@@ -22,6 +22,7 @@
 
 package com.bbn.openmap.dataAccess.iso8211;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.Vector;
 
@@ -207,7 +208,7 @@ public class DDFRecord implements DDFConstants {
         try {
             String recLength = new String(achLeader, 0, 5);
             String fieldAreaStart = new String(achLeader, 12, 5);
-            _recLength = Integer.valueOf(recLength).intValue();
+            _recLength = controlValidFileLength(Integer.valueOf(recLength).intValue());
             _fieldAreaStart = Integer.valueOf(fieldAreaStart).intValue();
         } catch (NumberFormatException nfe) {
 
@@ -362,7 +363,26 @@ public class DDFRecord implements DDFConstants {
         return true;
     }
 
-    /**
+    private int controlValidFileLength(int fileLength) {
+		return fileLength == 0 ? computeAwaitingFileLength(fileLength) : fileLength;
+	}
+
+	private int computeAwaitingFileLength(int fileLength) {
+		int _awaiting_file_length = 0;
+		try {
+			int _src_file_length = (int)this.poModule.getFileLength();
+			int _current_record_length = this.poModule.getRecordLength();
+			_awaiting_file_length = (_src_file_length - (_current_record_length + DDFConstants.DDF_FOOTER_SIZE));
+			
+		} catch (IOException e) {
+			e.printStackTrace();
+			return fileLength;
+		}
+		
+		return _awaiting_file_length;
+	}
+
+	/**
      * Find the named field within this record.
      * 
      * @param pszName The name of the field to fetch. The comparison


### PR DESCRIPTION
Instead of providing the patch as a Zip, I forked and patched.
The problem is that we got files for which header is not correctly parsed by OpenMap.
The consequence is that some fields are appearing as missing such as PRT.
This fix handles this case.