### PR TITLE
Extracted the min and max zoom levels to protected methods.

### DIFF
--- a/src/openmap/com/bbn/openmap/dataAccess/mapTile/AbstractMapTileCoordinateTransform.java
+++ b/src/openmap/com/bbn/openmap/dataAccess/mapTile/AbstractMapTileCoordinateTransform.java
@@ -106,8 +106,8 @@ public abstract class AbstractMapTileCoordinateTransform implements MapTileCoord
      * @return the zoom level.
      */
     public int getZoomLevelForProj(Projection proj, int zoomLevelTileSize) {
-        int low = 1;
-        int high = 20;
+        int low = getMinZoomLevelForProj();
+        int high = getMaxZoomLevelForProj();
 
         int ret = low;
         for (int currentZoom = low; currentZoom <= high; currentZoom++) {
@@ -134,6 +134,26 @@ public abstract class AbstractMapTileCoordinateTransform implements MapTileCoord
         }
 
         return ret;
+    }
+
+    /**
+     * Returns the minimum zoom level for calculating the appropriate zoom
+     * level.
+     * 
+     * @return minimum zoom level
+     */
+    protected int getMinZoomLevelForProj() {
+        return 1;
+    }
+
+    /**
+     * Returns the maximum zoom level for calculating the appropriate zoom
+     * level.
+     * 
+     * @return maximum zoom level
+     */
+    protected int getMaxZoomLevelForProj() {
+        return 20;
     }
 
     /**


### PR DESCRIPTION
We needed the ability to allow for higher zoom levels at least down to 22.  AbstractMapTileCoordinateTransform had the limitation on max zoom level to 20, this change allows me to define my custom Coordinate Transform class and override the max zoom level as needed.