### PR TITLE
fixed an issue with the map tiles not being reloaded.

### DIFF
--- a/src/openmap/com/bbn/openmap/image/BufferedImageHelper.java
+++ b/src/openmap/com/bbn/openmap/image/BufferedImageHelper.java
@@ -235,7 +235,9 @@ public class BufferedImageHelper {
         String path = url.getPath();
         boolean noAlpha = path.endsWith("jpg") || path.endsWith("jpeg");
 
-        return getBufferedImage(ii, x, y, w, h, !noAlpha);
+        BufferedImage bufferedImage = getBufferedImage(ii, x, y, w, h, !noAlpha);
+        ii.getImage().flush();
+        return bufferedImage;
     }
 
     /**


### PR DESCRIPTION
When local map tiles change the ImageIcon does not reload the underlying
image.  Calling flush on the image will clear the underlying resources,
so the next time the file is load it will re-read the image.