### PR TITLE
Fix for using a Tileserver when running in Java 8

### DIFF
--- a/src/openmap/com/bbn/openmap/layer/link/LinkLayer.java
+++ b/src/openmap/com/bbn/openmap/layer/link/LinkLayer.java
@@ -1282,8 +1282,8 @@ public class LinkLayer extends OMGraphicHandlerLayer implements
             center = GreatCircle.sphericalBetween(ProjMath.degToRad(latmax),
                                                   ProjMath.degToRad(lonmin),
                                                   dist, azimuth);
-            latitude = (float) center.getY();
-            longitude = (float) center.getX();
+            latitude = (float) center.getX();
+            longitude = (float) center.getY();
         }
 
         MapHandler mapHandler = (MapHandler) getBeanContext();

--- a/src/openmap/com/bbn/openmap/layer/link/LinkLayer.java
+++ b/src/openmap/com/bbn/openmap/layer/link/LinkLayer.java
@@ -237,7 +237,16 @@ public class LinkLayer extends OMGraphicHandlerLayer implements
      * Retrieves the current graphics list.
      */
     public synchronized LinkOMGraphicList getGraphicList() {
-        return (LinkOMGraphicList) getList();
+        try {
+            return (LinkOMGraphicList) getList();
+        }
+        catch (ClassCastException e) {
+            if (Debug.debugging("link"))
+            {
+                Debug.output("OMGraphicHandlerLayer does not currently have a LinkOMGraphicList.");
+            }
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
When running in Java 8 and setting up Openmap to use a tileserver, an unhandled ClassCastException appears in LinkLayer::getGraphicList(). This happens from It looks like the intention, looking at LinkLayer::handleLinkActionList(), it looks like the intention is to create the appropriate data structure **after** the first call to LinkLayer::getGraphicList(). Adding a catch here looks to fix the problem, and using a Tileserver works again.